### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "import",
     "images"
   ],
-  "docker_image": "supervisely/import-export:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "icon": "https://github.com/supervisely-ecosystem/import-images-in-sly-format-from-cloud-storage/assets/119248312/9cd0901c-fe90-4d9d-8981-91e287141f38",
   "icon_cover": true,
   "poster": "https://github.com/supervisely-ecosystem/import-images-in-sly-format-from-cloud-storage/assets/119248312/1e1551c4-7aaf-4ad5-b1bf-a850fbd39975",

--- a/config.json
+++ b/config.json
@@ -13,5 +13,5 @@
   "poster": "https://github.com/supervisely-ecosystem/import-images-in-sly-format-from-cloud-storage/assets/119248312/1e1551c4-7aaf-4ad5-b1bf-a850fbd39975",
   "entrypoint": "python -m uvicorn src.main:app --host 0.0.0.0 --port 8000",
   "port": 8000,
-  "min_instance_version": "6.15.35"
+  "instance_version": "6.15.60"
 }

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "import",
     "images"
   ],
-  "docker_image": "supervisely/import-export:6.73.486",
+  "docker_image": "supervisely/import-export:6.73.564",
   "icon": "https://github.com/supervisely-ecosystem/import-images-in-sly-format-from-cloud-storage/assets/119248312/9cd0901c-fe90-4d9d-8981-91e287141f38",
   "icon_cover": true,
   "poster": "https://github.com/supervisely-ecosystem/import-images-in-sly-format-from-cloud-storage/assets/119248312/1e1551c4-7aaf-4ad5-b1bf-a850fbd39975",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,1 @@
-# git+https://github.com/supervisely/supervisely.git@test-branch-name
 supervisely==6.73.564

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,2 @@
 # git+https://github.com/supervisely/supervisely.git@test-branch-name
-supervisely==6.73.486
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
